### PR TITLE
ruby and crystal formatting and changes

### DIFF
--- a/crystal/question.cr
+++ b/crystal/question.cr
@@ -1,19 +1,17 @@
-# implementation of the question function in crystal
-def question(prompt : String, valid : Array)
-  while true
+# Implementation of the question function in crystal
+def question(prompt : String, valid : Array(String)) : String
+  loop do
     puts prompt
-    print "(#{valid.join(", ")})" if valid.size != 0
+    print "(#{valid.join(", ")})" unless valid.empty?
     print ": "
 
     input = STDIN.gets
 
-    if valid.empty?
+    if !input.nil? && (valid.empty? || valid.includes?(input))
       return input
     else
-      return input if valid.includes? input
+      puts %("#{input}" is not a valid answer)
     end
-
-    puts %("#{input}" is not a valid answer)
   end
 end
 

--- a/crystal/question.cr
+++ b/crystal/question.cr
@@ -1,28 +1,20 @@
 # implementation of the question function in crystal
 def question(prompt : String, valid : Array)
-
   while true
-
-    puts  prompt
+    puts prompt
     print "(#{valid.join(", ")})" if valid.size != 0
     print ": "
 
     input = STDIN.gets
-    
+
     if valid.empty?
-
       return input
-    
     else
-
       return input if valid.includes? input
-    
     end
 
-    puts %("#{input}" is not a valid answer)  
-
+    puts %("#{input}" is not a valid answer)
   end
-
 end
 
 question("foo", ["bar", "baz"])

--- a/ruby/question.rb
+++ b/ruby/question.rb
@@ -1,19 +1,17 @@
 # Implementation of the question function in Ruby
 def question(prompt, valid)
   while true
-    puts  prompt
-    print "(#{valid.join(", ")})" if valid.size != 0
+    puts prompt
+    print "(#{valid.join ", "})" if valid.size != 0
     print ": "
-    input = STDIN.gets.chomp
+    input = gets.chomp
 
-    if valid.empty?
+    if valid.empty? || valid.include?(input)
       return input
     else
-      return input if valid.include? input
+      puts %("#{input}" is not a valid answer)
     end
-
-    puts %("#{input}" is not a valid answer)  
   end
 end
 
-question("foo", ["bar", "baz"])
+question "foo", ["bar", "baz"]

--- a/ruby/question.rb
+++ b/ruby/question.rb
@@ -1,6 +1,6 @@
 # Implementation of the question function in Ruby
-def question(prompt, valid)
-  while true
+def question prompt, valid
+  loop do
     puts prompt
     print "(#{valid.join ", "})" if valid.size != 0
     print ": "
@@ -14,4 +14,4 @@ def question(prompt, valid)
   end
 end
 
-question "foo", ["bar", "baz"]
+question "foo", %w(bar baz)


### PR DESCRIPTION
Ruby was made a little more free/weird, while crystal was made (slightly) more strict by utilizing types more.
Rufo was ran on the ruby code, and `crystal tool format` was ran on the crystal code.


also cleaned up the the way checks were being handled to make them unified
example psuedocode:
```
if a
  return input
else
  if b
    return input
```
was changed to
```
return input if a || b
```