### PR TITLE
oak-thesephist: init

### DIFF
--- a/oak-thesephist/flake.lock
+++ b/oak-thesephist/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1645013224,
+        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "flake-utils": "flake-utils"
+      },
+      "locked": {
+        "lastModified": 1639385028,
+        "narHash": "sha256-oqorKz3mwf7UuDJwlbCEYCB2LfcWLL0DkeCWhRIL820=",
+        "owner": "gytis-ivaskevicius",
+        "repo": "flake-utils-plus",
+        "rev": "be1be083af014720c14f3b574f57b6173b4915d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gytis-ivaskevicius",
+        "repo": "flake-utils-plus",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/oak-thesephist/flake.nix
+++ b/oak-thesephist/flake.nix
@@ -9,7 +9,8 @@
       inherit self inputs;
 
       outputsBuilder = channels:
-        let pkgs = channels.nixpkgs; in rec {
+        let pkgs = channels.nixpkgs; in
+        rec {
           packages = {
             oak =
               let
@@ -31,37 +32,38 @@
               };
           };
 
-          defaultApp = let name = "question-oak-thesphist"; in pkgs.stdenv.mkDerivation {
-            name = name;
-
-            src = builtins.path {
-              path = ./.;
+          defaultApp = let name = "question-oak-thesphist"; in
+            pkgs.stdenv.mkDerivation {
               name = name;
-            };
 
-            nativeBuildInputs = [
-              packages.oak
-              pkgs.makeWrapper
-            ];
+              src = builtins.path {
+                path = ./.;
+                name = name;
+              };
 
-            buildPhase = ''
-              runHook preBuild
+              nativeBuildInputs = [
+                packages.oak
+                pkgs.makeWrapper
+              ];
 
-              oak build --entry question.oak --output bundle.oak
+              buildPhase = ''
+                runHook preBuild
 
-              runHook postBuild
-            '';
+                oak build --entry question.oak --output bundle.oak
 
-            installPhase = ''
-              runHook preInstall
+                runHook postBuild
+              '';
+
+              installPhase = ''
+                runHook preInstall
                 
-              mkdir -p $out/bin
-              cp ./bundle.oak $out/bin/${name}.oak
-              makeWrapper ${packages.oak}/bin/oak $out/bin/${name} --add-flags $out/bin/${name}.oak
+                mkdir -p $out/bin
+                cp ./bundle.oak $out/bin/${name}.oak
+                makeWrapper ${packages.oak}/bin/oak $out/bin/${name} --add-flags $out/bin/${name}.oak
               
-              runHook postInstall
-            '';
-          };
+                runHook postInstall
+              '';
+            };
 
           devShell = pkgs.mkShell {
             name = "devshell";

--- a/oak-thesephist/flake.nix
+++ b/oak-thesephist/flake.nix
@@ -1,0 +1,72 @@
+{
+  inputs = {
+    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
+    utils.url = github:gytis-ivaskevicius/flake-utils-plus;
+  };
+
+  outputs = inputs@{ self, nixpkgs, utils }:
+    utils.lib.mkFlake {
+      inherit self inputs;
+
+      outputsBuilder = channels:
+        let pkgs = channels.nixpkgs; in rec {
+          packages = {
+            oak =
+              let
+                rev = "0edef240ed27c8f83e0a94bb27ca55a50c76c47c";
+              in
+              pkgs.buildGoModule {
+                pname = "oak";
+                version = rev;
+                src = pkgs.fetchFromGitHub {
+                  owner = "thesephist";
+                  repo = "oak";
+                  rev = rev;
+                  hash = "sha256-B83nC5i6AawAeBfOwk57uFrHAQZStML0vsWePxiQlWg=";
+                };
+
+                vendorSha256 = "sha256-iQtb3zNa57nB6x4InVPw7FCmW7XPw5yuz0OcfASXPD8=";
+
+                ldflags = [ "-s" "-w" ];
+              };
+          };
+
+          defaultApp = let name = "question-oak-thesphist"; in pkgs.stdenv.mkDerivation {
+            name = name;
+
+            src = builtins.path {
+              path = ./.;
+              name = name;
+            };
+
+            nativeBuildInputs = [
+              packages.oak
+              pkgs.makeWrapper
+            ];
+
+            buildPhase = ''
+              runHook preBuild
+
+              oak build --entry question.oak --output bundle.oak
+
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+                
+              mkdir -p $out/bin
+              cp ./bundle.oak $out/bin/${name}.oak
+              makeWrapper ${packages.oak}/bin/oak $out/bin/${name} --add-flags $out/bin/${name}.oak
+              
+              runHook postInstall
+            '';
+          };
+
+          devShell = pkgs.mkShell {
+            name = "devshell";
+            nativeBuildInputs = [ packages.oak ];
+          };
+        };
+    };
+}

--- a/oak-thesephist/question.oak
+++ b/oak-thesephist/question.oak
@@ -2,6 +2,7 @@ std := import('std')
 str := import('str')
 fmt := import('fmt')
 
+// implementation of the question function in oak
 fn question(prompt, valid) {
 	joined_prompt := if valid {
 		? -> prompt + ': '

--- a/oak-thesephist/question.oak
+++ b/oak-thesephist/question.oak
@@ -1,0 +1,23 @@
+std := import('std')
+str := import('str')
+fmt := import('fmt')
+
+fn question(prompt, valid) {
+	joined_prompt := if valid {
+		? -> prompt + ': '
+		_ -> fmt.format('{{0}}({{1}}): ', prompt, valid |> str.join(', '))
+	}
+
+	std.print(joined_prompt)
+	value := input().data |> str.trim()
+
+	if [valid, true] {
+		[?, _], [_, std.contains?(valid, value)] -> value
+		_ -> {
+			fmt.printf('"{{0}}" is not a valid answer', value)
+			question(prompt, valid)
+		}
+	}
+}
+
+question('foo', ['bar', 'baz'])


### PR DESCRIPTION
https://github.com/thesephist/oak

due to a naming conflict with the current oak implementation (a different language altogether), I'm using the username of the author of oak.

In the future, the current oak could possibly be named to oakc to fit with the repo name.